### PR TITLE
feat: enable stub_status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-docker-nginx-https-redirect
-===========================
+# docker-nginx-https-redirect
 
-A simple nginx container that redirects all http requests to https
+A simple nginx container that listen on 80 and redirects all http requests to https.
+
+The configuration includes a [stub_status](https://nginx.org/en/docs/http/ngx_http_stub_status_module.html) that listens on port 8181.
+
+Find Docker image at https://github.com/Carrefour-Group/docker-nginx-https-redirect/pkgs/container/nginx-https-redirect.

--- a/default.conf
+++ b/default.conf
@@ -1,5 +1,13 @@
 server {
-    listen         80;
-    server_tokens  off;
+    listen 80;
+    server_tokens off;
     return 301 https://$host$request_uri;
+}
+
+server {
+    listen 8181;
+    location /stub_status {
+        stub_status;
+        access_log off;
+    }
 }


### PR DESCRIPTION
Enable endpoint to expose stub_status in order to scrape metrics.
- https://nginx.org/en/docs/http/ngx_http_stub_status_module.html
- https://github.com/nginxinc/nginx-prometheus-exporter
